### PR TITLE
MODLD-568: Add surefire plugin to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-checkstyle-plugin.version>3.5.0</maven-checkstyle-plugin.version>
     <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
+    <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
   </properties>
 
   <dependencies>
@@ -164,6 +165,15 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
At present, tests are not executed in jenkins. So, Sonar shows 0% code coverage - https://sonarcloud.io/summary/overall?id=org.folio%3Alib-linked-data-dictionary 

This change should fix the problem.