### PR TITLE
MODLD-568: Add unit tests

### DIFF
--- a/src/test/java/org/folio/ld/dictionary/PropertyDictionaryTest.java
+++ b/src/test/java/org/folio/ld/dictionary/PropertyDictionaryTest.java
@@ -1,0 +1,48 @@
+package org.folio.ld.dictionary;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PropertyDictionaryTest {
+
+  @ParameterizedTest
+  @CsvSource({
+    "http://bibfra.me/vocab/marc/accessibilityNote, ACCESSIBILITY_NOTE",
+    "http://bibfra.me/vocab/marc/additionalPhysicalForm, ADDITIONAL_PHYSICAL_FORM",
+    "http://bibfra.me/vocab/marc/titles, TITLES",
+    "http://bibfra.me/vocab/marc/bibliographyNote, BIBLIOGRAPHY_NOTE",
+    "http://bibfra.me/vocab/marc/statementOfResponsibility, STATEMENT_OF_RESPONSIBILITY",
+  })
+  void fromValue_shouldReturnCorrectEnum(String value, PropertyDictionary expectedEnum) {
+    // when
+    var result = PropertyDictionary.fromValue(value);
+
+    // then
+    assertThat(result).contains(expectedEnum);
+  }
+
+  @Test
+  void fromNullValue_shouldNotContainValue() {
+    // when
+    var result = PropertyDictionary.fromValue(null);
+
+    // then
+    assertThat(result)
+      .isEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "non existing value"})
+  void fromInvalidValue_shouldNotContainValue(String value) {
+    // when
+    var result = PropertyDictionary.fromValue(value);
+
+    // then
+    assertThat(result)
+      .isEmpty();
+  }
+}

--- a/src/test/java/org/folio/ld/dictionary/model/ResourceEdgeTest.java
+++ b/src/test/java/org/folio/ld/dictionary/model/ResourceEdgeTest.java
@@ -1,0 +1,49 @@
+package org.folio.ld.dictionary.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.folio.ld.dictionary.PredicateDictionary;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ResourceEdgeTest {
+
+  @ParameterizedTest
+  @MethodSource("provideResourceEdgesForEqualsTest")
+  void testEquals(ResourceEdge edge1, ResourceEdge edge2, boolean expected) {
+    assertThat(edge1.equals(edge2)).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> provideResourceEdgesForEqualsTest() {
+    return Stream.of(
+      Arguments.of(
+        new ResourceEdge(new Resource().setId(1L), new Resource().setId(2L), PredicateDictionary.AUTHOR),
+        new ResourceEdge(new Resource().setId(1L), new Resource().setId(2L), PredicateDictionary.AUTHOR),
+        true
+      ),
+
+      // Different predicate
+      Arguments.of(
+        new ResourceEdge(new Resource().setId(1L), new Resource().setId(2L), PredicateDictionary.AUTHOR),
+        new ResourceEdge(new Resource().setId(1L), new Resource().setId(2L), PredicateDictionary.ARTIST),
+        false
+      ),
+
+      // Different source
+      Arguments.of(
+        new ResourceEdge(new Resource().setId(1L), new Resource().setId(2L), PredicateDictionary.AUTHOR),
+        new ResourceEdge(new Resource().setId(3L), new Resource().setId(2L), PredicateDictionary.AUTHOR),
+        false
+      ),
+
+      // Different target
+      Arguments.of(
+        new ResourceEdge(new Resource().setId(1L), new Resource().setId(2L), PredicateDictionary.AUTHOR),
+        new ResourceEdge(new Resource().setId(1L), new Resource().setId(3L), PredicateDictionary.AUTHOR),
+        false
+      )
+    );
+  }
+}

--- a/src/test/java/org/folio/ld/dictionary/model/ResourceTest.java
+++ b/src/test/java/org/folio/ld/dictionary/model/ResourceTest.java
@@ -1,0 +1,44 @@
+package org.folio.ld.dictionary.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.folio.ld.dictionary.PredicateDictionary;
+import org.folio.ld.dictionary.ResourceTypeDictionary;
+import org.junit.jupiter.api.Test;
+
+class ResourceTest {
+
+  @Test
+  void addType_shouldAddType() {
+    // given
+    var resource = new Resource();
+
+    // when
+    resource.addType(ResourceTypeDictionary.ID_LCCN);
+    resource.addType(ResourceTypeDictionary.IDENTIFIER);
+
+    // then
+    var typeNames = resource.getTypeNames();
+    assertThat(typeNames).containsExactlyInAnyOrder("ID_LCCN", "IDENTIFIER");
+  }
+
+
+  @Test
+  void addOutgoingEdge_shouldAddOutgoingEdge() {
+    // given
+    var sourceResource = new Resource();
+    var targetResource1 = new Resource();
+    var targetResource2 = new Resource();
+
+    var edge1 = new ResourceEdge(sourceResource, targetResource1, PredicateDictionary.AUTHOR);
+    var edge2 = new ResourceEdge(sourceResource, targetResource2, PredicateDictionary.ARTIST);
+
+    // when
+    sourceResource.addOutgoingEdge(edge1);
+    sourceResource.addOutgoingEdge(edge2);
+
+    // then
+    assertThat(sourceResource.getOutgoingEdges())
+      .containsExactlyInAnyOrder(edge1, edge2);
+  }
+}


### PR DESCRIPTION
At present, code coverage for lib-linked-data-dictionary is only 72% -> https://sonarcloud.io/summary/overall?id=org.folio%3Alib-linked-data-dictionary. TC need > 80% coverage.

This PR add more tests.