### PR TITLE
UILD-557: Remove extent literal property

### DIFF
--- a/src/main/java/org/folio/ld/dictionary/PropertyDictionary.java
+++ b/src/main/java/org/folio/ld/dictionary/PropertyDictionary.java
@@ -44,7 +44,6 @@ public enum PropertyDictionary {
   ENTITY_AND_ATTRIBUTE_INFORMATION("http://bibfra.me/vocab/marc/entityAndAttributeInformation"),
   EQUIVALENT("http://bibfra.me/vocab/lite/equivalent"),
   EXHIBITIONS_NOTE("http://bibfra.me/vocab/marc/exhibitionsNote"),
-  EXTENT("http://bibfra.me/vocab/lite/extent"),
   FIELD_LINK("http://bibfra.me/vocab/marc/fieldLink"),
   FORMER_TITLE_NOTE("http://bibfra.me/vocab/marc/formerTitleNote"),
   FORM_SUBDIVISION("http://bibfra.me/vocab/marc/formSubdivision"),


### PR DESCRIPTION
Removing extent literal property derived from MARC, leaving in extent object predicate. See https://github.com/folio-org/ui-linked-data/pull/188