### PR TITLE
MODLD-874: Add a serializer for Resource

### DIFF
--- a/src/main/java/org/folio/ld/dictionary/serializer/ResourceSerializer.java
+++ b/src/main/java/org/folio/ld/dictionary/serializer/ResourceSerializer.java
@@ -1,0 +1,96 @@
+package org.folio.ld.dictionary.serializer;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import org.folio.ld.dictionary.model.Resource;
+import org.folio.ld.dictionary.model.ResourceEdge;
+
+public class ResourceSerializer extends StdSerializer<Resource> {
+
+  private static final String FIELD_ID = "id";
+  private static final String FIELD_LABEL = "label";
+  private static final String FIELD_DOC = "doc";
+  private static final String FIELD_FOLIO_METADATA = "folioMetadata";
+  private static final String FIELD_UNMAPPED_MARC = "unmappedMarc";
+  private static final String FIELD_CREATED_DATE = "createdDate";
+  private static final String FIELD_UPDATED_DATE = "updatedDate";
+  private static final String FIELD_TYPES = "types";
+  private static final String FIELD_OUTGOING_EDGES = "outgoingEdges";
+
+  public ResourceSerializer() {
+    this(Resource.class);
+  }
+
+  public ResourceSerializer(Class<Resource> t) {
+    super(t);
+  }
+
+  @Override
+  public void serialize(Resource resource, JsonGenerator gen, SerializerProvider provider) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField(FIELD_ID, String.valueOf(resource.getId()));
+    gen.writeStringField(FIELD_LABEL, resource.getLabel());
+
+    if (resource.getDoc() != null) {
+      gen.writeObjectField(FIELD_DOC, resource.getDoc());
+    }
+    if (resource.getFolioMetadata() != null) {
+      provider.defaultSerializeField(FIELD_FOLIO_METADATA, resource.getFolioMetadata(), gen);
+    }
+    if (resource.getUnmappedMarc() != null) {
+      provider.defaultSerializeField(FIELD_UNMAPPED_MARC, resource.getUnmappedMarc(), gen);
+    }
+    if (resource.getCreatedDate() != null) {
+      gen.writeObjectField(FIELD_CREATED_DATE, resource.getCreatedDate());
+    }
+    if (resource.getUpdatedDate() != null) {
+      gen.writeObjectField(FIELD_UPDATED_DATE, resource.getUpdatedDate());
+    }
+
+    writeTypesArray(resource, gen);
+    writeOutgoingEdges(resource, gen, provider);
+
+    gen.writeEndObject();
+  }
+
+  private void writeOutgoingEdges(Resource resource,
+                                  JsonGenerator gen,
+                                  SerializerProvider provider) throws IOException {
+    if (resource.getOutgoingEdges() == null) {
+      return;
+    }
+
+    gen.writeObjectFieldStart(FIELD_OUTGOING_EDGES);
+
+    var predicateAndTargets = resource.getOutgoingEdges().stream()
+      .collect(groupingBy(
+        e -> e.getPredicate().getUri(),
+        LinkedHashMap::new,
+        mapping(ResourceEdge::getTarget, toList())
+      ));
+    for (var predicateAndTarget : predicateAndTargets.entrySet()) {
+      gen.writeArrayFieldStart(predicateAndTarget.getKey());
+      for (var target : predicateAndTarget.getValue()) {
+        provider.defaultSerializeValue(target, gen);
+      }
+      gen.writeEndArray();
+    }
+
+    gen.writeEndObject();
+  }
+
+  private void writeTypesArray(Resource resource, JsonGenerator gen) throws IOException {
+    gen.writeArrayFieldStart(FIELD_TYPES);
+    for (var type : resource.getTypes()) {
+      gen.writeString(type.getUri());
+    }
+    gen.writeEndArray();
+  }
+}

--- a/src/test/java/org/folio/ld/dictionary/serializer/ResourceSerializerTest.java
+++ b/src/test/java/org/folio/ld/dictionary/serializer/ResourceSerializerTest.java
@@ -1,0 +1,66 @@
+package org.folio.ld.dictionary.serializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.ld.dictionary.PredicateDictionary.INSTANTIATES;
+import static org.folio.ld.dictionary.ResourceTypeDictionary.INSTANCE;
+import static org.folio.ld.dictionary.ResourceTypeDictionary.WORK;
+import static org.folio.ld.dictionary.model.ResourceSource.LINKED_DATA;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.util.Set;
+import org.folio.ld.dictionary.model.FolioMetadata;
+import org.folio.ld.dictionary.model.RawMarc;
+import org.folio.ld.dictionary.model.Resource;
+import org.folio.ld.dictionary.model.ResourceEdge;
+import org.junit.jupiter.api.Test;
+
+class ResourceSerializerTest {
+
+  @Test
+  void testResourceSerialization() throws Exception {
+    var mapper = new ObjectMapper()
+      .registerModule(new SimpleModule().addSerializer(Resource.class, new ResourceSerializer()));
+
+    var resource1 = new Resource()
+      .setId(1L)
+      .setLabel("Main Resource")
+      .setTypes(Set.of(INSTANCE))
+      .setFolioMetadata(new FolioMetadata().setInventoryId("inv-123").setSource(LINKED_DATA).setSrsId("srs-456"))
+      .setUnmappedMarc(new RawMarc().setContent("{ '008': 'some data' }"))
+      .setDoc(mapper.readTree("{ \"someField\": \"someValue\" }"));
+
+    var resource2 = new Resource()
+      .setId(2L)
+      .setLabel("Target Resource")
+      .setTypes(Set.of(WORK));
+
+    var edge = new ResourceEdge(resource1, resource2, INSTANTIATES);
+    resource2.setIncomingEdges(Set.of(edge));
+    resource1.addOutgoingEdge(edge);
+
+    var resultJson = mapper.writeValueAsString(resource1);
+
+    var expectedJson = """
+      {
+        "id": "1",
+        "label": "Main Resource",
+        "doc": { "someField": "someValue" },
+        "folioMetadata": { "inventoryId": "inv-123", "source": "LINKED_DATA", "srsId": "srs-456" },
+        "unmappedMarc": { "content": "{ '008': 'some data' }" },
+        "types": [ "http://bibfra.me/vocab/lite/Instance" ],
+        "outgoingEdges": {
+          "http://bibfra.me/vocab/lite/instantiates": [
+            {
+              "id": "2",
+              "label": "Target Resource",
+              "types": [ "http://bibfra.me/vocab/lite/Work" ],
+              "outgoingEdges": {}
+            }
+          ]
+        }
+      }""";
+
+    assertThat(mapper.readTree(resultJson)).isEqualTo(mapper.readTree(expectedJson));
+  }
+}

--- a/src/test/java/org/folio/ld/dictionary/serializer/ResourceSerializerTest.java
+++ b/src/test/java/org/folio/ld/dictionary/serializer/ResourceSerializerTest.java
@@ -2,6 +2,7 @@ package org.folio.ld.dictionary.serializer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.ld.dictionary.PredicateDictionary.INSTANTIATES;
+import static org.folio.ld.dictionary.PredicateDictionary.TITLE;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.INSTANCE;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.WORK;
 import static org.folio.ld.dictionary.model.ResourceSource.LINKED_DATA;
@@ -39,6 +40,10 @@ class ResourceSerializerTest {
     resource2.setIncomingEdges(Set.of(edge));
     resource1.addOutgoingEdge(edge);
 
+    var cycleEdge = new ResourceEdge(resource2, resource1, TITLE);
+    resource1.setIncomingEdges(Set.of(cycleEdge));
+    resource2.addOutgoingEdge(cycleEdge);
+
     var resultJson = mapper.writeValueAsString(resource1);
 
     var expectedJson = """
@@ -55,7 +60,13 @@ class ResourceSerializerTest {
               "id": "2",
               "label": "Target Resource",
               "types": [ "http://bibfra.me/vocab/lite/Work" ],
-              "outgoingEdges": {}
+              "outgoingEdges": {
+                "http://bibfra.me/vocab/library/title": [
+                  {
+                    "id": "1"
+                  }
+                ]
+              }
             }
           ]
         }


### PR DESCRIPTION
Without this custom serializer, the [new search Resource API](https://github.com/folio-org/mod-linked-data/pull/330/files#diff-28c8b2e9a94750c2f4083c79755d414b81ee357bca80a8ea5d14c8386762bda3R91) fails with following error

```
[HttpMessageNotWritableException] Could not write JSON: Document nesting depth (1001) exceeds the maximum allowed (1000, from StreamWriteConstraints.getMaxNestingDepth())
```


This happens because of the recursive structure between [Resource](https://github.com/folio-org/lib-linked-data-dictionary/blob/master/src/main/java/org/folio/ld/dictionary/model/Resource.java) and [ResourceEdge](https://github.com/folio-org/lib-linked-data-dictionary/blob/master/src/main/java/org/folio/ld/dictionary/model/ResourceEdge.java#L16) (Resource contains ResourceEdges, and ResourceEdges point back to Resources).

One alternative to writing a serializer would be to return the raw `resourceSubgraph` JSON string from the [new search API](https://github.com/folio-org/mod-linked-data/pull/330/files#diff-28c8b2e9a94750c2f4083c79755d414b81ee357bca80a8ea5d14c8386762bda3R91). That avoids deserializing into a Resource object [here](https://github.com/folio-org/mod-linked-data/pull/330/files#diff-28c8b2e9a94750c2f4083c79755d414b81ee357bca80a8ea5d14c8386762bda3R95) and then spring serializing it again for sending the Resource across the wire. The drawback is that the API contract would just contain a String response, which makes it unclear what the content actually represents. What do you think?

Also, I think we need this serializer in the future when publishing resources from mod-linked-data-import to Kafka ( [MODLDI-6](https://folio-org.atlassian.net/browse/MODLDI-6)). 

Since both `mod-linked-data` and `mod-linked-data-import` will require it, I thought it is better to add the serializer to a shared library. If we are ok with this, we should probably move the [Deserializer](https://github.com/folio-org/lib-linked-data-rdf4ld/blob/master/src/main/java/org/folio/rdf4ld/util/ExportedResourceDeserializer.java)
also to this repo. I can open a small tech ticket for that.